### PR TITLE
Use container rdfs:member item instead of item rdfs:member container

### DIFF
--- a/documentation/example.ttl
+++ b/documentation/example.ttl
@@ -49,14 +49,14 @@ _:col1  a edpopcol:Collection ;
 
 # TOY DATA
 
-_:Hamlet        rdfs:member _:col1 .
-_:Claudius      rdfs:member _:col1 .
-_:Gertrude      rdfs:member _:col1 .
-_:Horatio       rdfs:member _:col1 .
-_:Ophelia       rdfs:member _:col1 .
-_:Roosencrantz  rdfs:member _:col1 .
-_:Guildenstern  rdfs:member _:col1 .
-_:Ghost         rdfs:member _:col1 .
+_:col1 rdfs:member _:Hamlet .
+_:col1 rdfs:member _:Claudius .
+_:col1 rdfs:member _:Gertrude .
+_:col1 rdfs:member _:Horatio .
+_:col1 rdfs:member _:Ophelia .
+_:col1 rdfs:member _:Roosencrantz .
+_:col1 rdfs:member _:Guildenstern .
+_:col1 rdfs:member _:Ghost .
 
 # Some initial propositions about the data.
 

--- a/documentation/guidelines.md
+++ b/documentation/guidelines.md
@@ -60,7 +60,7 @@ Note that even this case, context and membership are different things. Consider 
 
 ```ttl
 _:GreatAuthors a edpopcol:Collection .
-_:Shakespeare rdfs:member _:GreatAuthors .
+_:GreatAuthors rdfs:member _:Shakespeare .
 
 _:a1  a edpopcol:Annotation ;
     oa:hasTarget [ oa:hasSource _:Shakespeare ] .


### PR DESCRIPTION
I missed this when I reviewed #2.

rdfs:member is an ambiguous name for a property; it could either mean that the subject is a member of the object, or that the object is a member of the subject. The former would more clearly be named "memberOf" and is what has been suggested in the documentation before this change. The latter would more clearly be named "hasMember" and appears to be the correct interpretation of the property.

For a motivation why the container should be the subject and not the object, see the following references:

https://www.w3.org/TR/rdf-schema/#ch_containermembershipproperty
https://www.w3.org/TR/rdf-schema/#ch_sumproperties