### PR TITLE
Add specialized selector for edpoprec:Record fields

### DIFF
--- a/ontology.ttl
+++ b/ontology.ttl
@@ -140,7 +140,7 @@ edpopcol:object     a rdf:Property ;
                     rdfs:label "object"@en ;
                     rdfs:comment "The object of the predicate"@en .
 
-# ANNOTATION SOURCES
+# ANNOTATION SELECTORS
 
 edpopcol:PredicateSelector  rdfs:subClassOf oa:Selector ;
                             rdfs:subClassOf edpopcol:Predicate ;

--- a/ontology.ttl
+++ b/ontology.ttl
@@ -8,6 +8,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 
+@prefix edpoprec: <https://dhstatic.hum.uu.nl/edpop-records/0.1.0/> .
 @prefix edpopcol:  <https://dhstatic.hum.uu.nl/edpop-collection/0.1.0-SNAPSHOT#>  .
 
 edpopcol:   a owl:Ontology ;
@@ -140,12 +141,35 @@ edpopcol:object     a rdf:Property ;
                     rdfs:label "object"@en ;
                     rdfs:comment "The object of the predicate"@en .
 
+# FIELD DESCRIPTORS
+# to make annotations specifically on edpoprec:Record fields
+
+edpopcol:Field        a rdfs:Class ;
+                      rdfs:label "Field"@en ;
+                      rdfs:comment "A description of a field of a record"@en .
+
+edpopcol:field        a rdf:Property ;
+                      rdfs:domain edpopcol:Field ;
+                      rdfs:range rdf:Property ;
+                      rdfs:label "field"@en ;
+                      rdfs:comment "The field property of the record"@en .
+
+edpopcol:originalText a rdf:Property ;
+                      rdfs:domain edpopcol:Field ;
+                      rdfs:range xsd:string ;
+                      rdfs:label "original text"@en ;
+                      rdfs:comment "The original text of a particular instance of the field"@en .
+
 # ANNOTATION SELECTORS
 
 edpopcol:PredicateSelector  rdfs:subClassOf oa:Selector ;
                             rdfs:subClassOf edpopcol:Predicate ;
                             rdfs:label "Predicate Selector"@en ;
                             rdfs:comment "Selects a predicate on a resource to annotate."@en .
+
+edpopcol:FieldSelector      rdfs:subClassOf oa:Selector , edpopcol:Field ;
+                            rdfs:label "Field Selector"@en ;
+                            rdfs:comment "Selects a field on a record to annotate."@en .
 
 # ANNOTATION BODIES
 


### PR DESCRIPTION
After I discussed this with @tijmenbaarda, I took a hard stare at both ontologies and the current logic in the EDPOP VRE. The existing, more generic `edpopcol:PredicateSelector` is kind of half-usable for record fields: the `edpopcol:property` can identify a field on the record, but the `edpopcol:object` cannot easily identify particular instances of the field because those are blank nodes with nested properties.

The existing practice in the VRE is to identify the instances by their `edpoprec:originalText` instead. My proposed changes follow this approach, leaving the more generic `edpopcol:PredicateSelector` untouched so that it can still be used as originally intended.

A minor disadvantage of this approach is that it introduces tacit knowledge about the record ontology into the collection ontology. For completeness, I will mention two other possible approaches that I have briefly considered. Neither of these alternatives introduces tacit knowledge about the record ontology, but I think they have the more important disadvantage of convoluting the data model and complicating application logic in the VRE as a result. Please feel welcome to discuss this tradeoff, and possible other approaches, in your review.

1. Generalize the `edpopcol:Predicate` so that it can also select property *chains*. In this case, selectors in the EDPOP VRE would use two-member chains where the first member is the field property on the record and the second member is always `edpoprec:originalText`. The `edpopcol:object` would be set to the string value of the original text.
2. Nest another `edpopcol:Predicate` inside the `edpopcol:object`. This recursive structure could be used to arbitrary depth in principle. The nested predicate would always have `edpoprec:originalText` as its `edpopcol:property` and the string value of the original text as its `edpopcol:object`.